### PR TITLE
Added possibility to select "optional skills" when searching for slots

### DIFF
--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -31,4 +31,6 @@ COPY --from=frontend app/frontend/dist/frontend ./frontend
 RUN ls -a -l /app/backend/dist/**
 
 WORKDIR /app/backend
-CMD [ "src/scripts/start.sh" ]
+
+RUN apt-get update && apt-get install -y dos2unix && dos2unix start.sh
+CMD [ "./start.sh" ]

--- a/workbench/backend/src/app/booking/booking.controller.ts
+++ b/workbench/backend/src/app/booking/booking.controller.ts
@@ -18,6 +18,7 @@ class Job {
     public readonly durationMinutes: number,
     public readonly location: Readonly<{ latitude: number; longitude: number; }>,
     public readonly mandatorySkills: string[],
+    public readonly optionalSkills: string[],
     public readonly udfValues: Readonly<{ [key: string]: string }>,
   ) { }
 }

--- a/workbench/backend/src/common/optimisation-api.dao.ts
+++ b/workbench/backend/src/common/optimisation-api.dao.ts
@@ -11,6 +11,7 @@ export type SearchRequest = Readonly<{
     durationMinutes: number;
     location: Readonly<ILocation>;
     mandatorySkills: string[];
+    optionalSkills?: string[];
     udfValues: {
       [key: string]: string;
     }

--- a/workbench/backend/start.sh
+++ b/workbench/backend/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+set -x
+
+echo "START SERVER";
+cd dist && node main.js

--- a/workbench/frontend/src/app/slot-booking/components/job-builder/job-builder.component.html
+++ b/workbench/frontend/src/app/slot-booking/components/job-builder/job-builder.component.html
@@ -8,27 +8,59 @@
         <div>
           <p>matching :{{ matchingResourceCount$ | async }} </p>
         </div>
-        <mat-chip-list #tagList>
+        <mat-chip-list #mandatorySkillsList>
 
-          <mat-chip *ngFor="let tagName of (selectTags$ | async)" [removable]="removable" (removed)="remove(tagName)">
+          <mat-chip *ngFor="let tagName of (selectedMandatorySkills$ | async)" [removable]="removable" (removed)="removeMandatorySkill(tagName)">
             {{ tagName }}
             <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
           </mat-chip>
 
-          <input placeholder="add mandatory skills ..." #tagInput [formControl]="tagsCtrl" [matAutocomplete]="auto"
-            [matChipInputFor]="tagList" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-            (matChipInputTokenEnd)="addNew($event)">
-
         </mat-chip-list>
 
-        <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
+
+        <mat-autocomplete #autoMandatorySkill="matAutocomplete" (optionSelected)="mandatorySkillsSelectionChanged($event)">
           <mat-option *ngFor="let tag of (filteredTags$ | async)" [value]="tag.name">
             {{ tag.name }} ({{ tag.persons.length }})
           </mat-option>
         </mat-autocomplete>
 
+        <input placeholder="add mandatory skills ..." #mandatorySkillsInput [formControl]="mandatorySkillsCtrl" [matAutocomplete]="autoMandatorySkill"
+               [matChipInputFor]="mandatorySkillsList" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+               (matChipInputTokenEnd)="addMandatorySkill($event)">
+
       </mat-form-field>
+
     </div>
+
+
+
+    <div style="margin-top: 10px;">
+      <mat-form-field style="width: 500px">
+        <mat-chip-list #optionalSkillsList>
+
+          <mat-chip *ngFor="let tagName of (selectedOptionalSkills$ | async)" [removable]="removable" (removed)="removeOptionalSkill(tagName)">
+            {{ tagName }}
+            <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
+          </mat-chip>
+
+        </mat-chip-list>
+
+
+        <mat-autocomplete #autoOptionalSkill="matAutocomplete" (optionSelected)="optionalSkillsSelectionChanged($event)">
+          <mat-option *ngFor="let tag of (filteredTags$ | async)" [value]="tag.name">
+            {{ tag.name }} ({{ tag.persons.length }})
+          </mat-option>
+        </mat-autocomplete>
+
+
+        <input placeholder="add optional skills ..." #optionalSkillsInput [formControl]="optionalSkillsCtrl" [matAutocomplete]="autoOptionalSkill"
+               [matChipInputFor]="optionalSkillsList" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+               (matChipInputTokenEnd)="addOptionalSkill($event)">
+
+      </mat-form-field>
+
+    </div>
+
 
     <div style="margin-top: 10px;">
       <mat-form-field appearance="fill" style="width: 500px">

--- a/workbench/frontend/src/app/slot-booking/services/job.service.ts
+++ b/workbench/frontend/src/app/slot-booking/services/job.service.ts
@@ -12,6 +12,7 @@ export type Job = {
     longitude: number
   } | null,
   mandatorySkills: string[],
+  optionalSkills: string[]
 }
 
 export type TagDTO = {

--- a/workbench/frontend/src/app/slot-booking/services/slot-booking.service.ts
+++ b/workbench/frontend/src/app/slot-booking/services/slot-booking.service.ts
@@ -53,6 +53,7 @@ export type SearchRequest = Readonly<{
     durationMinutes: number;
     location: Readonly<ILocation>;
     mandatorySkills: string[];
+    optionalSkills?: string[];
     udfValues: {
       [key: string]: string;
     }

--- a/workbench/frontend/src/app/slot-booking/slot-booking.component.html
+++ b/workbench/frontend/src/app/slot-booking/slot-booking.component.html
@@ -39,12 +39,12 @@
               </mat-spinner>
             </div>
             <div style="padding-left: 20px;">
-            
+
               <div class="tech-info">
                 <mat-icon>tag</mat-icon>
                 <span>{{ item.score }}</span>
               </div>
-              
+
               <div class="tech-info">
                 <mat-icon>access_time</mat-icon>
                 <span>{{ item.start | date:'HH:mm' }} - {{ item.end | date:'HH:mm' }}</span>
@@ -54,7 +54,7 @@
                 <mat-icon>directions_car</mat-icon>
                 <span>{{ item.trip.durationInMinutes }} min ({{ (item.trip.distanceInMeters / 1000 ) }} km)</span>
               </div>
-            
+
             </div>
           </div>
 
@@ -134,7 +134,7 @@
 <mat-expansion-panel class="margin-10">
   <mat-expansion-panel-header>
     <mat-panel-title>
-      <strong class="panel-title">🕑&nbsp;&nbsp;When / Timeing </strong>
+      <strong class="panel-title">🕑&nbsp;&nbsp;When / Timing </strong>
       <mat-chip class="panel-title-chip"> {{ (requestPayload$ | async)?.slots.length }} slots </mat-chip>
     </mat-panel-title>
     <mat-panel-description></mat-panel-description>

--- a/workbench/frontend/src/app/slot-booking/slot-booking.component.ts
+++ b/workbench/frontend/src/app/slot-booking/slot-booking.component.ts
@@ -66,6 +66,7 @@ export class SlotBookingComponent implements OnInit, OnDestroy {
               durationMinutes: job.durationMinutes,
               location: job.location,
               mandatorySkills: job.mandatorySkills,
+              optionalSkills: job.optionalSkills,
               udfValues: {}
             },
 
@@ -128,7 +129,7 @@ export class SlotBookingComponent implements OnInit, OnDestroy {
       take(1),
       mergeMap(payload => {
 
-        // options here  
+        // options here
 
         return this.service.doRequest(payload).pipe(
           catchError((error) => {


### PR DESCRIPTION
This pull request enables the user to not only add mandatory but also optional skills as job search criteria, when searching for slots. Find the corresponding field and drop down selection under "Slot Search Options" in the "Where/Job" section right after "add mandatory skills"